### PR TITLE
Search checks for city and users can only edit and delete their own products

### DIFF
--- a/Bangazon/Controllers/ProductsController.cs
+++ b/Bangazon/Controllers/ProductsController.cs
@@ -42,7 +42,7 @@ namespace Bangazon.Controllers
             {
                 var applicationDbContext1 = _context.Product.Include(p => p.ProductType)
                    .Include(p => p.User)
-                   .Where(p => p.Title.Contains(SearchProduct) || p.City.Contains(SearchProduct))
+                   .Where(p => p.Title.Contains(SearchProduct) || p.City.ToLower() == SearchProduct.ToLower())
                    .OrderByDescending(p => p.DateCreated);
 
                 return View(await applicationDbContext1.ToListAsync());

--- a/Bangazon/Controllers/ProductsController.cs
+++ b/Bangazon/Controllers/ProductsController.cs
@@ -35,12 +35,14 @@ namespace Bangazon.Controllers
         [Authorize]
         public async Task<IActionResult> Index(string SearchProduct)
         {
+            var currentUser = await GetCurrentUserAsync();
+            ViewBag.UserId = currentUser.Id;
             // if searchBox is not empty then filter product list
             if (SearchProduct != null)
             {
                 var applicationDbContext1 = _context.Product.Include(p => p.ProductType)
                    .Include(p => p.User)
-                   .Where(p => p.Title.Contains(SearchProduct))
+                   .Where(p => p.Title.Contains(SearchProduct) || p.City.Contains(SearchProduct))
                    .OrderByDescending(p => p.DateCreated);
 
                 return View(await applicationDbContext1.ToListAsync());

--- a/Bangazon/appsettings.json
+++ b/Bangazon/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost\\SQLExpress02;Database=BangazonSite;Trusted_Connection=True;"
+    "DefaultConnection": "Server=localhost\\SQLExpress;Database=BangazonSite;Trusted_Connection=True;"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
# Description
The search box can now be used to search for products in a particular city. The city name much match the searched input entirely. For example "nash" will not show products in "nashville". I also fixed a bug that was preventing the details and edit button from showing on products.

## Type of change
Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# Testing Instructions for Change Made
1. `git fetch --all`
2. `git checkout branchdressing`
3. `start BangazonSite.sln`
4. Run Bangazon server and test search bar


# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings


# Ticket:
https://github.com/nss-day-cohort-30/bangazon-site-billowy-beluga/issues/13